### PR TITLE
Fix exit code API in `run()` method.

### DIFF
--- a/bin/emsdk-run
+++ b/bin/emsdk-run
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 BINDIR=`dirname "$0"`
 DIR=`dirname "$BINDIR"`
 

--- a/src/common.js
+++ b/src/common.js
@@ -42,7 +42,7 @@ function run(command, args) {
         }
     );
     child.on('exit', (e) => {
-        process.exit(e.code);
+        process.exit(e);
     });
     child.on('error', (err) => {
         throw err;


### PR DESCRIPTION
Fixes the error code callback argument value from `child_process.spawn()`, which return a `number` (as opposed to an object with a `code` property) going back as far as [node 0.12.x](https://nodejs.org/docs/latest-v0.12.x/api/child_process.html#child_process_child_process_spawn_command_args_options).

Fixes `emsdk-run` shell to qualify `bash` for bash-specific substitution.